### PR TITLE
generate non random number sequences

### DIFF
--- a/main.js
+++ b/main.js
@@ -10,12 +10,19 @@
 (function() {
     'use strict';
     let elements = [];
+
+    const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    let counter = 0; // to count the sequence AA, AB etc
+
     function get_prefix(length = 2) {
-        const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
         let result = '';
+        let tempCounter = counter;
+
         for (let i = 0; i < length; i++) {
-            result += characters.charAt(Math.floor(Math.random() * characters.length));
+            result = characters.charAt(tempCounter % characters.length) + result;
+            tempCounter = Math.floor(tempCounter / characters.length);
         }
+        counter++;
         return result;
     }
     
@@ -70,8 +77,9 @@
     let typedSequence = '';
     let active = false;
     document.addEventListener('keydown', (event) => {
-        if (event.ctrlKey && event.key === '<' && !active) {
+        if (event.ctrlKey && event.altKey && !active) {
             event.preventDefault();
+            counter = 0; // reset to reuse AA, AB next call
             typedSequence = '';
             active = true;
             initializeLeafNodes();
@@ -81,8 +89,9 @@
             return;
         }
 
-        if (event.key == "Escape") {
+        if (event.key == "Escape" || (event.ctrlKey && event.altKey)) {
             resetNodes();
+
             typedSequence = "";
             active = false;
             return;

--- a/main.js
+++ b/main.js
@@ -25,11 +25,20 @@
         counter++;
         return result;
     }
-    // Function to check if element is visible in the viewport
-    const isVisible = (el) => {
-        const rect = el.getBoundingClientRect();
-        return rect.width > 0 && rect.height > 0 && rect.top < window.innerHeight && rect.left < window.innerWidth;
-    };
+    // Function to check if an element is visible
+    function isVisible(element) {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+
+        // Check if element has non-zero dimensions and is within the viewport
+        return (rect.width > 1 && rect.height > 1 &&
+                style.display !== 'none' &&
+                style.visibility !== 'hidden' &&
+                style.opacity !== '0' &&
+                rect.top >= 0 && rect.left >= 0 &&
+                rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+                rect.right <= (window.innerWidth || document.documentElement.clientWidth));
+    }
     // Function to initialize each leaf node by changing the first two characters
     function initializeLeafNodes() {
         const allElements = document.querySelectorAll('*');

--- a/main.js
+++ b/main.js
@@ -25,13 +25,17 @@
         counter++;
         return result;
     }
-    
+    // Function to check if element is visible in the viewport
+    const isVisible = (el) => {
+        const rect = el.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0 && rect.top < window.innerHeight && rect.left < window.innerWidth;
+    };
     // Function to initialize each leaf node by changing the first two characters
     function initializeLeafNodes() {
         const allElements = document.querySelectorAll('*');
 
         allElements.forEach(e => {
-            if ((e.getAttribute('onclick')!=null)||(e.getAttribute('href')!=null)||(e.tagName == "BUTTON")) { // Only clickable nodes
+            if (isVisible(e) && ((e.getAttribute('onclick')!=null)||(e.getAttribute('href')!=null)||(e.tagName == "BUTTON"))) { // Only clickable nodes
                 if (e.tagName == "DIV") {
                     return;
                 }
@@ -44,7 +48,7 @@
                 newDiv.style = "font-weight: bold; color: blue;"
                 e.prepend(newDiv)
             }            
-            if (e.tagName == "INPUT" && e.type == "text") {
+            if (e.tagName == "INPUT" && e.type == "text" && isVisible(e)) {
                 elements.push(e);
                 const prefix = get_prefix();
                 e.dataset.originalPH = e.placeholder;


### PR DESCRIPTION
changed get_prefix to show non random character
```
    function get_prefix(length = 2) {
        let result = '';
        let tempCounter = counter;

        for (let i = 0; i < length; i++) {
            result = characters.charAt(tempCounter % characters.length) + result;
            tempCounter = Math.floor(tempCounter / characters.length);
        }
        counter++;
        return result;
    }
```


however, the code seems to also add prefix to buttons and links that are not accessible on the page, the result is that on github for example, you start at "AY"